### PR TITLE
cicd: ignore assert check in tests

### DIFF
--- a/python/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/python/{{cookiecutter.project_slug}}/pyproject.toml
@@ -138,4 +138,5 @@ ignore = [
 # ANN102 - missing-type-cls
 # ANN2 - missing-return-type
 # S101 - assert
-"tests/*" = ["ANN001", "ANN102", "ANN2", "S101"]
+# B011 - assert-false
+"tests/*" = ["ANN001", "ANN102", "ANN2", "S101", "B011"]

--- a/python/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/python/{{cookiecutter.project_slug}}/pyproject.toml
@@ -135,4 +135,5 @@ ignore = [
 # ANN001 - missing-type-function-argument
 # ANN102 - missing-type-cls
 # ANN2 - missing-return-type
-"tests/*" = ["ANN001", "ANN102", "ANN2"]
+# S101 - assert
+"tests/*" = ["ANN001", "ANN102", "ANN2", "S101"]

--- a/python/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/python/{{cookiecutter.project_slug}}/pyproject.toml
@@ -123,12 +123,14 @@ fixable = [
 # E117 - over-indented*
 # E501 - line-too-long*
 # W191 - tab-indentation*
+# S321 - suspicious-ftp-lib-usage
 # *ignored for compatibility with formatter
 ignore = [
     "ANN101", "ANN003",
     "D203", "D205", "D206", "D213", "D300", "D400", "D415",
     "E111", "E114", "E117", "E501",
-    "W191"
+    "W191",
+    "S321",
 ]
 
 [tool.ruff.per-file-ignores]


### PR DESCRIPTION
Ran through a few projects as testbeds for the ruff rules and found a few tweaks that we should make. Calling this "priority:high" because this repo is sort of acting as a source of truth for other repos (and it's a small fix).