### PR TITLE
style: pin ruff version

### DIFF
--- a/python/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/python/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.14
+    rev: v0.1.15
     hooks:
       - id: ruff-format
       - id: ruff

--- a/python/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/python/{{cookiecutter.project_slug}}/pyproject.toml
@@ -25,7 +25,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 tests = ["pytest", "pytest-cov"]
-dev = ["pre-commit", "ruff>=0.1.14"]
+dev = ["pre-commit", "ruff==0.1.15"]
 {% if cookiecutter.add_docs %}
 docs = [
     "sphinx==6.1.3",


### PR DESCRIPTION
noticed a funny bug today. Latest Ruff version designated something as a fail. Added a `noqa` to ignore it. Pre-commit can only be tagged with specific ruff versions, and it flagged that `noqa` as "unused". 

In a way, every new minor Ruff update has a chance to be "breaking" (in terms of causing fails in CI that were passing before) so I think it might make general good sense to be pinning this stuff and then updating every 3-6 months unless we see a new feature we really want.