### PR TITLE
style: exclude docs config for format and lint

### DIFF
--- a/python/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/python/{{cookiecutter.project_slug}}/pyproject.toml
@@ -64,9 +64,9 @@ branch = true
 
 [tool.ruff]
 src = ["src"]
+{% if cookiecutter.add_docs %}exclude = ["docs/source/conf.py"]{% endif %}
 
 [tool.ruff.lint]
-{% if cookiecutter.add_docs %}exclude = ["docs/source/conf.py"]{% endif %}
 select = [
     "F",  # https://docs.astral.sh/ruff/rules/#pyflakes-f
     "E", "W",  # https://docs.astral.sh/ruff/rules/#pycodestyle-e-w


### PR DESCRIPTION
Previously, the docs config is only ignored for linting. This moves it up to be ignored when formatting, also.

I think this was just been an oversight from when the Ruff config rules got restructured.