### PR TITLE
cicd(python): add priority label PR action

### DIFF
--- a/python/{{cookiecutter.project_slug}}/.github/workflows/pr-priority-label.yaml
+++ b/python/{{cookiecutter.project_slug}}/.github/workflows/pr-priority-label.yaml
@@ -1,0 +1,23 @@
+name: Pull Request Has Priority Label
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+jobs:
+  pr-priority-label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    outputs:
+      status: ${{ steps.check-labels.outputs.status }}
+    steps:
+      - id: check-labels
+        uses: mheap/github-action-required-labels@v5
+        with:
+          mode: exactly
+          count: 1
+          labels: "priority:*"
+          use_regex: true
+          add_comment: true
+          message: "PRs require a priority label. Please add one."
+          exit_type: failure

--- a/python/{{cookiecutter.project_slug}}/.github/workflows/pr-priority-label.yaml
+++ b/python/{{cookiecutter.project_slug}}/.github/workflows/pr-priority-label.yaml
@@ -9,7 +9,7 @@ jobs:
       issues: write
       pull-requests: write
     outputs:
-      status: ${{ steps.check-labels.outputs.status }}
+      status: {{ "${{ steps.check-labels.outputs.status }}" }}
     steps:
       - id: check-labels
         uses: mheap/github-action-required-labels@v5


### PR DESCRIPTION
This was added to the repo root, but not to the cookiecutter template itself -- this PR adds it to the template, as well (and we can copy out from there)