### PR TITLE
cicd(python): use GITHUB_TOKEN for changelog permissions

### DIFF
--- a/python/{{cookiecutter.project_slug}}/.github/workflows/checks.yaml
+++ b/python/{{cookiecutter.project_slug}}/.github/workflows/checks.yaml
@@ -43,7 +43,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     env:
-      SPHINX_GITHUB_CHANGELOG_TOKEN: {{ "${{ secrets.SPHINX_GITHUB_CHANGELOG_TOKEN }}" }}
+      SPHINX_GITHUB_CHANGELOG_TOKEN: {{ "${{ secrets.GITHUB_TOKEN }}" }}
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
I figured this out too late, but there's a built-in token with sufficient permissions to support the test for building the autochangelog from GitHub releases. This PR uses it.