### PR TITLE
feat(python): move support to >=3.10

### DIFF
--- a/python/{{cookiecutter.project_slug}}/.github/workflows/checks.yaml
+++ b/python/{{cookiecutter.project_slug}}/.github/workflows/checks.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
 

--- a/python/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/python/{{cookiecutter.project_slug}}/pyproject.toml
@@ -11,13 +11,11 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 description = "{{ cookiecutter.description }}"
 license = {file = "LICENSE"}
 dependencies = []


### PR DESCRIPTION
* Reflect Biocommons policy of supporting the three most recent full Python releases. Lets us take advantage of some recent features, including some nicer type annotation syntax.
* Will entail some minor work implementing new [pyupgrade](https://docs.astral.sh/ruff/rules/#pyupgrade-up) linter rules exposed by moving the `requires-python` setting up
* Suggested by @korikuzma somewhere (Slack?)