### PR TITLE
feat(python): add issue templates

### DIFF
--- a/python/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/python/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,0 +1,85 @@
+name: Bug Report
+description: Report a bug.
+labels: ["bug"]
+body:
+  - type: textarea
+    attributes:
+      label: Describe the bug
+      description: Provide a clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Steps to reproduce
+      description: Provide detailed steps to replicate the bug.
+      placeholder: |
+        1. In this environment...
+        2. With this config...
+        3. Run '...'
+        4. See error...
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Current behavior
+      description: |
+        What actually happened?
+
+        Include full errors, stack traces, and/or relevant logs.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Possible reason(s)
+      description: Provide any insights into what might be causing the issue.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Suggested fix
+      description: Provide any suggestions on how to resolve the bug.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Branch, commit, and/or version
+      description: Provide the branch, commit, and/or version you're using.
+      placeholder: |
+        branch: issue-1
+        commit: abc123d
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots with descriptions to help explain your problem.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Environment details
+      description: Provide environment details (OS name and version, etc).
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional details
+      description: Provide any other additional details about the problem.
+    validations:
+      required: false
+  - type: dropdown
+    attributes:
+      label: Contribution
+      description: Can you contribute to the development of this feature?
+      options:
+        - "Yes, I can create a PR for this fix."
+        - "Yes, but I can only provide ideas and feedback."
+        - "No, I cannot contribute."
+    validations:
+      required: true

--- a/python/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/python/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -1,0 +1,60 @@
+name: Feature Request
+description: Suggest an idea for this project.
+labels: ["enhancement"]
+body:
+  - type: textarea
+    attributes:
+      label: Feature description
+      description: Provide a clear and concise description of what you want to happen.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Use case
+      description: |
+        Why do you need this feature? For example: "I'm always frustrated when..."
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Proposed solution
+      description: Provide proposed solution.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Alternatives considered
+      description: Describe any alternative solutions you've considered.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Implementation details
+      description: Provide any technical details on how the feature might be implemented.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Potential Impact
+      description: |
+        Discuss any potential impacts of this feature on existing functionality or performance, if known.
+        Will this feature cause breaking changes?
+        What challenges might arise?
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Provide any other context or screenshots about the feature.
+    validations:
+      required: false
+  - type: dropdown
+    attributes:
+      label: Contribution
+      description: Can you contribute to the development of this feature?
+      options:
+        - "Yes, I can create a PR for this feature."
+        - "Yes, but I can only provide ideas and feedback."
+        - "No, I cannot contribute."
+    validations:
+      required: true


### PR DESCRIPTION
These issue templates exist in this repo, but this issue adds them to the cookiecutter template that creates new Python projects also