### PR TITLE
chore: make contribution optional in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -82,4 +82,4 @@ body:
         - "Yes, but I can only provide ideas and feedback."
         - "No, I cannot contribute."
     validations:
-      required: true
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -57,4 +57,4 @@ body:
         - "Yes, but I can only provide ideas and feedback."
         - "No, I cannot contribute."
     validations:
-      required: true
+      required: false


### PR DESCRIPTION
I think this is good for outside collaborators for our open-source projects, but don't think it should be required