### PR TITLE
build(python): use setuptools-scm

### DIFF
--- a/python/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/python/{{cookiecutter.project_slug}}/pyproject.toml
@@ -52,6 +52,8 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools_scm]
+
 [tool.pytest.ini_options]
 addopts = "--cov=src --cov-report term-missing"
 testpaths = ["tests"]


### PR DESCRIPTION
close #16 

* simplifies release workflow: rather than maintaining both a `version.py` file and a git tag for the release, the installed package gets its version number directly from the git tag
* one less file
* clarifies version metadata for in-progress releases because they get a giant commit hash at the end of them 

outstanding issue: entails some changes to our version patterns and behavior, discuss in https://github.com/GenomicMedLab/wagner-lab-issues/discussions/28. I think this also sets us up to move towards semantic release/release please, although we probably still have some steps to get there.