### PR TITLE
cicd: update min required python version

### DIFF
--- a/.github/workflows/update-python.yaml
+++ b/.github/workflows/update-python.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'  # use minimum supported Python version
+          python-version: '3.10'  # use minimum supported Python version
 
       - name: Install latest Ruff
         run: python3 -m pip install ruff


### PR DESCRIPTION
I missed this when doing the 3.10 update