### PR TITLE
fix(pre-commit): add --allow-missing-credentials arg

### DIFF
--- a/python/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/python/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
       - id: end-of-file-fixer
       - id: check-merge-conflict
       - id: detect-aws-credentials
+        args: [ --allow-missing-credentials ]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: 0.5.0  # ruff version
     hooks:


### PR DESCRIPTION
Or else we get the following:

```
No AWS keys were found in the configured credential files and environment variables.
Please ensure you have the correct setting for --credentials-file
```