### PR TITLE
fix(cicd): generate correctly formatted ruff value for precommit

### DIFF
--- a/.github/workflows/update-python.yaml
+++ b/.github/workflows/update-python.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Update Ruff version in .pre-commit-config.yaml
         run: |
-          sed -i "s/rev: .*  # ruff version/rev: ${{ env.RUFF_VERSION }}  # ruff version/" ${{ env.PYTHON_TEMPLATE_LOCATION }}/.pre-commit-config.yaml
+          sed -i "s/rev: .*  # ruff version/rev: v${{ env.RUFF_VERSION }}  # ruff version/" ${{ env.PYTHON_TEMPLATE_LOCATION }}/.pre-commit-config.yaml
 
       - name: Create new branch for changes
         run: |

--- a/python/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/python/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: detect-aws-credentials
         args: [ --allow-missing-credentials ]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 0.5.0  # ruff version
+    rev: v0.5.0  # ruff version
     hooks:
       - id: ruff-format
       - id: ruff


### PR DESCRIPTION
I thiiiiink this is correct

I am also increasingly of the opinion that this special Ruff hook might be more trouble than it's worth, there's a way to define a custom hook that might make more sense, and would rely on the environment's ruff rather than a special precommit-only ruff