### PR TITLE
feat(python): ignore doc requirements in tests

### DIFF
--- a/python/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/python/{{cookiecutter.project_slug}}/pyproject.toml
@@ -147,10 +147,21 @@ ignore = [
 # ANN001 - missing-type-function-argument
 # ANN2 - missing-return-type
 # ANN102 - missing-type-cls
+# D100 - undocumented-public-module
+# D102 - undocumented-public-class
 # S101 - assert
 # B011 - assert-false
 # INP001 - implicit-namespace-package
-"tests/*" = ["ANN001", "ANN2", "ANN102", "S101", "B011", "INP001"]
+"tests/*" = [
+    "ANN001",
+    "ANN2",
+    "ANN102",
+    "D100",
+    "D102",
+    "S101",
+    "B011",
+    "INP001"
+]
 
 [tool.ruff.lint.flake8-annotations]
 mypy-init-return = true


### PR DESCRIPTION
Pytest functions really don't need docstrings in the sense that you never actually call those functions... if we want to add extra details using the docstring space, that's fine, but I don't think it should be required for every test