### PR TITLE
fix(python): use rev tag for workflow ref

### DIFF
--- a/python/{{cookiecutter.project_slug}}/.github/workflows/stale.yaml
+++ b/python/{{cookiecutter.project_slug}}/.github/workflows/stale.yaml
@@ -6,21 +6,21 @@ on:
 
 jobs:
   stale-high-priority:
-    uses: genomicmedlab/software-templates/.github/workflows/reusable-stale.yaml
+    uses: genomicmedlab/software-templates/.github/workflows/reusable-stale.yaml@main
     with:
       days-before-issue-stale: 90
       days-before-pr-stale: 1
       labels: priority:high
 
   stale-medium-priority:
-    uses: genomicmedlab/software-templates/.github/workflows/reusable-stale.yaml
+    uses: genomicmedlab/software-templates/.github/workflows/reusable-stale.yaml@main
     with:
       days-before-issue-stale: 135
       days-before-pr-stale: 3
       labels: priority:medium
 
   stale-low-priority:
-    uses: genomicmedlab/software-templates/.github/workflows/reusable-stale.yaml
+    uses: genomicmedlab/software-templates/.github/workflows/reusable-stale.yaml@main
     with:
       days-before-issue-stale: 180
       days-before-pr-stale: 7


### PR DESCRIPTION
I think this was fixed in most repos but missed in the template.