### PR TITLE
feat: add fastapi + service_info endpoint

### DIFF
--- a/python/cookiecutter.json
+++ b/python/cookiecutter.json
@@ -6,5 +6,6 @@
     "repo": "{{ cookiecutter.project_slug }}",
     "your_name": "",
     "your_email": "",
-    "add_docs": [false, true]
+    "add_docs": [false, true],
+    "add_fastapi": [false, true]
 }

--- a/python/hooks/post_gen_project.py
+++ b/python/hooks/post_gen_project.py
@@ -13,4 +13,5 @@ if not {{ cookiecutter.add_fastapi }}:
     Path("tests/test_api.py").unlink()
     Path("src/{{ cookiecutter.project_slug }}/api.py").unlink()
     Path("src/{{ cookiecutter.project_slug }}/models.py").unlink()
+    Path("src/{{ cookiecutter.project_slug }}/config.py").unlink()
     Path("src/{{ cookiecutter.project_slug }}/logging.py").unlink()

--- a/python/hooks/post_gen_project.py
+++ b/python/hooks/post_gen_project.py
@@ -1,4 +1,5 @@
 """Provide hooks to run after project is generated."""
+
 from pathlib import Path
 import shutil
 
@@ -6,3 +7,10 @@ import shutil
 if not {{ cookiecutter.add_docs }}:
     shutil.rmtree("docs")
     Path(".readthedocs.yaml").unlink()
+
+
+if not {{ cookiecutter.add_fastapi }}:
+    Path("tests/test_api.py").unlink()
+    Path("src/{{ cookiecutter.project_slug }}/api.py").unlink()
+    Path("src/{{ cookiecutter.project_slug }}/models.py").unlink()
+    Path("src/{{ cookiecutter.project_slug }}/logging.py").unlink()

--- a/python/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/python/{{cookiecutter.project_slug}}/pyproject.toml
@@ -25,7 +25,11 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-tests = ["pytest", "pytest-cov"]
+tests = [
+    "pytest",
+    "pytest-cov",
+{% if cookiecutter.add_fastapi %}    "httpx",{% endif %}
+]
 dev = ["pre-commit>=3.7.1", "ruff==0.5.0"]
 {% if cookiecutter.add_docs %}docs = [
     "sphinx==6.1.3",

--- a/python/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/python/{{cookiecutter.project_slug}}/pyproject.toml
@@ -18,14 +18,16 @@ classifiers = [
 requires-python = ">=3.11"
 description = "{{ cookiecutter.description }}"
 license = {file = "LICENSE"}
-dependencies = []
+dependencies = [
+{% if cookiecutter.add_fastapi %}    "fastapi",
+    "pydantic~=2.1",{% endif %}
+]
 dynamic = ["version"]
 
 [project.optional-dependencies]
 tests = ["pytest", "pytest-cov"]
 dev = ["pre-commit>=3.7.1", "ruff==0.5.0"]
-{% if cookiecutter.add_docs %}
-docs = [
+{% if cookiecutter.add_docs %}docs = [
     "sphinx==6.1.3",
     "sphinx-autodoc-typehints==1.22.0",
     "sphinx-autobuild==2021.3.14",
@@ -33,8 +35,7 @@ docs = [
     "sphinxext-opengraph==0.8.2",
     "furo==2023.3.27",
     "sphinx-github-changelog==1.2.1"
-]
-{% endif %}
+]{% endif %}
 
 [project.urls]
 Homepage = "https://github.com/{{ cookiecutter.org }}/{{ cookiecutter.repo }}"

--- a/python/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/python/{{cookiecutter.project_slug}}/pyproject.toml
@@ -113,16 +113,12 @@ select = [
     "ARG",  # https://docs.astral.sh/ruff/rules/#flake8-unused-arguments-arg
     "PTH",  # https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth
     "PGH",  # https://docs.astral.sh/ruff/rules/#pygrep-hooks-pgh
-<<<<<<< HEAD
 {%- if cookiecutter.add_fastapi %}
     "FAST",  # https://docs.astral.sh/ruff/rules/#fastapi-fast
 {%- endif %}
-||||||| 3f458e3
-=======
     "PLC",  # https://docs.astral.sh/ruff/rules/#convention-c
     "PLE",  # https://docs.astral.sh/ruff/rules/#error-e_1
     "TRY",  # https://docs.astral.sh/ruff/rules/#tryceratops-try
->>>>>>> main
     "PERF",  # https://docs.astral.sh/ruff/rules/#perflint-perf
     "FURB",  # https://docs.astral.sh/ruff/rules/#refurb-furb
     "RUF",  # https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf
@@ -141,16 +137,12 @@ fixable = [
     "PT",
     "RSE",
     "SIM",
-<<<<<<< HEAD
 {%- if cookiecutter.add_fastapi %}
     "FAST",
 {%- endif %}
-||||||| 3f458e3
-=======
     "PLC",
     "PLE",
     "TRY",
->>>>>>> main
     "PERF",
     "FURB",
     "RUF"

--- a/python/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/python/{{cookiecutter.project_slug}}/pyproject.toml
@@ -18,20 +18,27 @@ classifiers = [
 requires-python = ">=3.11"
 description = "{{ cookiecutter.description }}"
 license = {file = "LICENSE"}
+{%- if cookiecutter.add_fastapi %}
 dependencies = [
-{% if cookiecutter.add_fastapi %}    "fastapi",
-    "pydantic~=2.1",{% endif %}
+    "fastapi",
+    "pydantic~=2.1",
 ]
+{% else %}
+dependencies = []
+{% endif -%}
 dynamic = ["version"]
 
 [project.optional-dependencies]
 tests = [
     "pytest",
     "pytest-cov",
-{% if cookiecutter.add_fastapi %}    "httpx",{% endif %}
+{%- if cookiecutter.add_fastapi %}
+    "httpx",
+{%- endif %}
 ]
 dev = ["pre-commit>=3.7.1", "ruff==0.5.0"]
-{% if cookiecutter.add_docs %}docs = [
+{%- if cookiecutter.add_docs %}
+docs = [
     "sphinx==6.1.3",
     "sphinx-autodoc-typehints==1.22.0",
     "sphinx-autobuild==2021.3.14",
@@ -39,7 +46,8 @@ dev = ["pre-commit>=3.7.1", "ruff==0.5.0"]
     "sphinxext-opengraph==0.8.2",
     "furo==2023.3.27",
     "sphinx-github-changelog==1.2.1"
-]{% endif %}
+]
+{% endif %}
 
 [project.urls]
 Homepage = "https://github.com/{{ cookiecutter.org }}/{{ cookiecutter.repo }}"
@@ -101,6 +109,9 @@ select = [
     "ARG",  # https://docs.astral.sh/ruff/rules/#flake8-unused-arguments-arg
     "PTH",  # https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth
     "PGH",  # https://docs.astral.sh/ruff/rules/#pygrep-hooks-pgh
+{%- if cookiecutter.add_fastapi %}
+    "FAST",  # https://docs.astral.sh/ruff/rules/#fastapi-fast
+{%- endif %}
     "PERF",  # https://docs.astral.sh/ruff/rules/#perflint-perf
     "FURB",  # https://docs.astral.sh/ruff/rules/#refurb-furb
     "RUF",  # https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf
@@ -119,6 +130,9 @@ fixable = [
     "PT",
     "RSE",
     "SIM",
+{%- if cookiecutter.add_fastapi %}
+    "FAST",
+{%- endif %}
     "PERF",
     "FURB",
     "RUF"

--- a/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/__init__.py
+++ b/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/__init__.py
@@ -1,4 +1,5 @@
 """{{ cookiecutter.description }}"""
+
 from importlib.metadata import PackageNotFoundError, version
 
 

--- a/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/api.py
+++ b/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/api.py
@@ -1,15 +1,15 @@
 """Define API endpoints."""
 
-from enum import Enum
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
-from typing import AsyncGenerator
+from enum import Enum
 
 from fastapi import FastAPI
 
 from {{ cookiecutter.project_slug }} import __version__
-from {{ cookiecutter.project_slug }}.models import ServiceInfo, ServiceOrganization, ServiceType
 from {{ cookiecutter.project_slug }}.config import config
 from {{ cookiecutter.project_slug }}.logging import initialize_logs
+from {{ cookiecutter.project_slug }}.models import ServiceInfo, ServiceOrganization, ServiceType
 
 
 @asynccontextmanager
@@ -64,7 +64,5 @@ def service_info() -> ServiceInfo:
     :return: conformant service info description
     """
     return ServiceInfo(
-        organization=ServiceOrganization(),
-        type=ServiceType(),
-        environment=config.env
+        organization=ServiceOrganization(), type=ServiceType(), environment=config.env
     )

--- a/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/api.py
+++ b/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/api.py
@@ -10,6 +10,7 @@ from {{ cookiecutter.project_slug }}.config import config
 
 
 # TODO add logging configuration
+# make this module add to main
 
 
 class _Tag(str, Enum):

--- a/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/api.py
+++ b/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/api.py
@@ -1,9 +1,17 @@
 """Define API endpoints."""
 
+from enum import Enum
+
 from fastapi import FastAPI
 
 from {{ cookiecutter.project_slug }} import __version__
-from {{ cookiecutter.project_slug }}.models import ServiceInfo
+from {{ cookiecutter.project_slug }}.models import ServiceInfo, ServiceOrganization, ServiceType
+
+
+class _Tag(str, Enum):
+    """Define tag names for endpoints."""
+
+    META = "Meta"
 
 
 app = FastAPI(
@@ -30,11 +38,13 @@ app = FastAPI(
     summary="Get basic service information",
     response_model=ServiceInfo,
     description="Retrieve service metadata, such as versioning and contact info. Structured in conformance with the [GA4GH service info API specification](https://www.ga4gh.org/product/service-info/)",
-    tags=["Meta"],
+    tags=[
+        _Tag.META,
+    ],
 )
 def service_info() -> ServiceInfo:
     """Provide service info per GA4GH Service Info spec
 
     :return: conformant service info description
     """
-    return ServiceInfo()
+    return ServiceInfo(organization=ServiceOrganization(), type=ServiceType())

--- a/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/api.py
+++ b/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/api.py
@@ -54,9 +54,7 @@ app = FastAPI(
     summary="Get basic service information",
     response_model=ServiceInfo,
     description="Retrieve service metadata, such as versioning and contact info. Structured in conformance with the [GA4GH service info API specification](https://www.ga4gh.org/product/service-info/)",
-    tags=[
-        _Tag.META,
-    ],
+    tags=[_Tag.META],
 )
 def service_info() -> ServiceInfo:
     """Provide service info per GA4GH Service Info spec

--- a/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/api.py
+++ b/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/api.py
@@ -1,16 +1,27 @@
 """Define API endpoints."""
 
 from enum import Enum
+from contextlib import asynccontextmanager
+from typing import AsyncGenerator
 
 from fastapi import FastAPI
 
 from {{ cookiecutter.project_slug }} import __version__
 from {{ cookiecutter.project_slug }}.models import ServiceInfo, ServiceOrganization, ServiceType
 from {{ cookiecutter.project_slug }}.config import config
+from {{ cookiecutter.project_slug }}.logging import initialize_logs
 
 
-# TODO add logging configuration
-# make this module add to main
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncGenerator:
+    """Perform operations that interact with the lifespan of the FastAPI instance.
+
+    See https://fastapi.tiangolo.com/advanced/events/#lifespan.
+
+    :param app: FastAPI instance
+    """
+    initialize_logs()
+    yield
 
 
 class _Tag(str, Enum):
@@ -52,7 +63,6 @@ def service_info() -> ServiceInfo:
 
     :return: conformant service info description
     """
-
     return ServiceInfo(
         organization=ServiceOrganization(),
         type=ServiceType(),

--- a/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/api.py
+++ b/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/api.py
@@ -13,7 +13,7 @@ from {{ cookiecutter.project_slug }}.models import ServiceInfo, ServiceOrganizat
 
 
 @asynccontextmanager
-async def lifespan(app: FastAPI) -> AsyncGenerator:
+async def lifespan(app: FastAPI) -> AsyncGenerator:  # noqa: ARG001
     """Perform operations that interact with the lifespan of the FastAPI instance.
 
     See https://fastapi.tiangolo.com/advanced/events/#lifespan.
@@ -52,7 +52,6 @@ app = FastAPI(
 @app.get(
     "/service_info",
     summary="Get basic service information",
-    response_model=ServiceInfo,
     description="Retrieve service metadata, such as versioning and contact info. Structured in conformance with the [GA4GH service info API specification](https://www.ga4gh.org/product/service-info/)",
     tags=[_Tag.META],
 )

--- a/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/api.py
+++ b/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/api.py
@@ -1,0 +1,40 @@
+"""Define API endpoints."""
+
+from fastapi import FastAPI
+
+from {{ cookiecutter.project_slug }} import __version__
+from {{ cookiecutter.project_slug }}.models import ServiceInfo
+
+
+app = FastAPI(
+    title="{{ cookiecutter.project_slug }}",
+    description="{{ cookiecutter.description }}",
+    version=__version__,
+    contact={
+        "name": "Alex H. Wagner",
+        "email": "Alex.Wagner@nationwidechildrens.org",
+        "url": "https://www.nationwidechildrens.org/specialties/institute-for-genomic-medicine/research-labs/wagner-lab",
+    },
+    license={
+        "name": "MIT",
+        "url": "https://github.com/{{ cookiecutter.org }}/{{ cookiecutter.repo }}/blob/main/LICENSE",
+    },
+    docs_url="/docs",
+    openapi_url="/openapi.json",
+    swagger_ui_parameters={"tryItOutEnabled": True},
+)
+
+
+@app.get(
+    "/service_info",
+    summary="Get basic service information",
+    response_model=ServiceInfo,
+    description="Retrieve service metadata, such as versioning and contact info. Structured in conformance with the [GA4GH service info API specification](https://www.ga4gh.org/product/service-info/)",
+    tags=["Meta"],
+)
+def service_info() -> ServiceInfo:
+    """Provide service info per GA4GH Service Info spec
+
+    :return: conformant service info description
+    """
+    return ServiceInfo()

--- a/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/api.py
+++ b/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/api.py
@@ -6,6 +6,10 @@ from fastapi import FastAPI
 
 from {{ cookiecutter.project_slug }} import __version__
 from {{ cookiecutter.project_slug }}.models import ServiceInfo, ServiceOrganization, ServiceType
+from {{ cookiecutter.project_slug }}.config import config
+
+
+# TODO add logging configuration
 
 
 class _Tag(str, Enum):
@@ -47,4 +51,9 @@ def service_info() -> ServiceInfo:
 
     :return: conformant service info description
     """
-    return ServiceInfo(organization=ServiceOrganization(), type=ServiceType())
+
+    return ServiceInfo(
+        organization=ServiceOrganization(),
+        type=ServiceType(),
+        environment=config.env
+    )

--- a/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/config.py
+++ b/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/config.py
@@ -3,7 +3,7 @@
 import logging
 import os
 
-from .models import Config, ServiceEnvironment
+from {{ cookiecutter.project_slug }}.models import Config, ServiceEnvironment
 
 
 _logger = logging.getLogger(__name__)

--- a/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/config.py
+++ b/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/config.py
@@ -5,7 +5,7 @@ import os
 
 from pydantic import BaseModel
 
-from {{ cookiecutter.project_slug }}.models import Config, ServiceEnvironment
+from {{ cookiecutter.project_slug }}.models import ServiceEnvironment
 
 
 _logger = logging.getLogger(__name__)

--- a/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/config.py
+++ b/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/config.py
@@ -3,7 +3,7 @@
 import logging
 import os
 
-from .models import ServiceEnvironment, Config
+from .models import Config, ServiceEnvironment
 
 
 _logger = logging.getLogger(__name__)
@@ -13,39 +13,24 @@ _ENV_VARNAME = "{{ cookiecutter.project_slug | upper }}"
 
 
 def _dev_config() -> Config:
-    return Config(
-        env=ServiceEnvironment.DEV,
-        debug=True,
-        test=False
-    )
+    return Config(env=ServiceEnvironment.DEV, debug=True, test=False)
 
 
 def _test_config() -> Config:
-    return Config(
-        env=ServiceEnvironment.TEST,
-        debug=False,
-        test=True
-    )
+    return Config(env=ServiceEnvironment.TEST, debug=False, test=True)
 
 
 def _staging_config() -> Config:
-    return Config(
-        env=ServiceEnvironment.STAGING,
-        debug=False,
-        test=False,
-    )
+    return Config(env=ServiceEnvironment.STAGING, debug=False, test=False)
 
 
 def _prod_config() -> Config:
-    return Config(
-        env=ServiceEnvironment.PROD,
-        debug=False,
-        test=False,
-    )
+    return Config(env=ServiceEnvironment.PROD, debug=False, test=False)
 
 
 def _default_config():
     return _dev_config()
+
 
 _CONFIG_MAP = {
     ServiceEnvironment.DEV: _dev_config,
@@ -66,7 +51,11 @@ def _set_config() -> Config:
     try:
         env_value = ServiceEnvironment(raw_env_value.lower())
     except ValueError:
-        _logger.error("Unrecognized value for %s: %s. Using default configs", _ENV_VARNAME, raw_env_value)
+        _logger.error(
+            "Unrecognized value for %s: %s. Using default configs",
+            _ENV_VARNAME,
+            raw_env_value
+        )
         return _default_config()
     return _CONFIG_MAP[env_value]()
 

--- a/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/config.py
+++ b/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/config.py
@@ -3,6 +3,8 @@
 import logging
 import os
 
+from pydantic import BaseModel
+
 from {{ cookiecutter.project_slug }}.models import Config, ServiceEnvironment
 
 
@@ -10,6 +12,14 @@ _logger = logging.getLogger(__name__)
 
 
 _ENV_VARNAME = "{{ cookiecutter.project_slug | upper }}_ENV"
+
+
+class Config(BaseModel):
+    """Define app configuration data object."""
+
+    env: ServiceEnvironment
+    debug: bool
+    test: bool
 
 
 def _dev_config() -> Config:

--- a/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/config.py
+++ b/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/config.py
@@ -9,26 +9,46 @@ from .models import Config, ServiceEnvironment
 _logger = logging.getLogger(__name__)
 
 
-_ENV_VARNAME = "{{ cookiecutter.project_slug | upper }}"
+_ENV_VARNAME = "{{ cookiecutter.project_slug | upper }}_ENV"
 
 
 def _dev_config() -> Config:
+    """Provide development environment configs
+
+    :return: dev env configs
+    """
     return Config(env=ServiceEnvironment.DEV, debug=True, test=False)
 
 
 def _test_config() -> Config:
+    """Provide test env configs
+
+    :return: test configs
+    """
     return Config(env=ServiceEnvironment.TEST, debug=False, test=True)
 
 
 def _staging_config() -> Config:
+    """Provide staging env configs
+
+    :return: staging configs
+    """
     return Config(env=ServiceEnvironment.STAGING, debug=False, test=False)
 
 
 def _prod_config() -> Config:
+    """Provide production configs
+
+    :return: prod configs
+    """
     return Config(env=ServiceEnvironment.PROD, debug=False, test=False)
 
 
-def _default_config():
+def _default_config() -> Config:
+    """Provide default configs. This function sets what they are.
+
+    :return: default configs
+    """
     return _dev_config()
 
 

--- a/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/config.py
+++ b/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/config.py
@@ -1,0 +1,74 @@
+"""Read and provide runtime configuration."""
+
+import logging
+import os
+
+from .models import ServiceEnvironment, Config
+
+
+_logger = logging.getLogger(__name__)
+
+
+_ENV_VARNAME = "{{ cookiecutter.project_slug | upper }}"
+
+
+def _dev_config() -> Config:
+    return Config(
+        env=ServiceEnvironment.DEV,
+        debug=True,
+        test=False
+    )
+
+
+def _test_config() -> Config:
+    return Config(
+        env=ServiceEnvironment.TEST,
+        debug=False,
+        test=True
+    )
+
+
+def _staging_config() -> Config:
+    return Config(
+        env=ServiceEnvironment.STAGING,
+        debug=False,
+        test=False,
+    )
+
+
+def _prod_config() -> Config:
+    return Config(
+        env=ServiceEnvironment.PROD,
+        debug=False,
+        test=False,
+    )
+
+
+def _default_config():
+    return _dev_config()
+
+_CONFIG_MAP = {
+    ServiceEnvironment.DEV: _dev_config,
+    ServiceEnvironment.TEST: _test_config,
+    ServiceEnvironment.STAGING: _staging_config,
+    ServiceEnvironment.PROD: _prod_config,
+}
+
+
+def _set_config() -> Config:
+    """Set configs based on environment variable `{{ cookiecutter.project_slug | upper }}_ENV`.
+
+    :return: complete config object with environment-specific parameters
+    """
+    raw_env_value = os.environ.get(_ENV_VARNAME)
+    if not raw_env_value:
+        return _default_config()
+    try:
+        env_value = ServiceEnvironment(raw_env_value.lower())
+    except ValueError:
+        _logger.error("Unrecognized value for %s: %s. Using default configs", _ENV_VARNAME, raw_env_value)
+        return _default_config()
+    return _CONFIG_MAP[env_value]()
+
+
+config = _set_config()

--- a/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/config.py
+++ b/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/config.py
@@ -72,7 +72,7 @@ def _set_config() -> Config:
         env_value = ServiceEnvironment(raw_env_value.lower())
     except ValueError:
         _logger.error(
-            "Unrecognized value for %s: %s. Using default configs",
+            "Unrecognized value for %s: '%s'. Using default configs",
             _ENV_VARNAME,
             raw_env_value
         )

--- a/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/logging.py
+++ b/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/logging.py
@@ -1,0 +1,17 @@
+"""Configure application logging."""
+
+import logging
+
+
+def initialize_logs(log_level: int = logging.DEBUG) -> None:
+    """Configure logging.
+
+    :param log_level: global log level to set
+    """
+    log_filename = f"{__package__}.log"
+    logging.basicConfig(
+        filename=log_filename,
+        format="[%(asctime)s] - %(name)s - %(levelname)s : %(message)s",
+    )
+    logger = logging.getLogger(__package__)
+    logger.setLevel(log_level)

--- a/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/logging.py
+++ b/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/logging.py
@@ -6,7 +6,7 @@ import logging
 def initialize_logs(log_level: int = logging.DEBUG) -> None:
     """Configure logging.
 
-    :param log_level: global log level to set
+    :param log_level: app log level to set
     """
     log_filename = f"{__package__}.log"
     logging.basicConfig(

--- a/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/logging.py
+++ b/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/logging.py
@@ -8,9 +8,8 @@ def initialize_logs(log_level: int = logging.DEBUG) -> None:
 
     :param log_level: app log level to set
     """
-    log_filename = f"{__package__}.log"
     logging.basicConfig(
-        filename=log_filename,
+        filename=f"{__package__}.log",
         format="[%(asctime)s] - %(name)s - %(levelname)s : %(message)s",
     )
     logger = logging.getLogger(__package__)

--- a/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/models.py
+++ b/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/models.py
@@ -8,6 +8,23 @@ from pydantic import BaseModel
 from . import __version__
 
 
+class ServiceEnvironment(str, Enum):
+    """Define current runtime environment."""
+
+    DEV = "dev"
+    PROD = "prod"
+    TEST = "test"
+    STAGING = "staging"
+
+
+class Config(BaseModel):
+    """Define app configuration data object."""
+
+    env: ServiceEnvironment
+    debug: bool
+    test: bool
+
+
 class ServiceOrganization(BaseModel):
     """Define service_info response for organization field"""
 
@@ -25,15 +42,6 @@ class ServiceType(BaseModel):
     group: Literal["org.genomicmedlab"] = "org.genomicmedlab"
     artifact: Literal["{{ cookiecutter.project_slug }} API"] = "{{ cookiecutter.project_slug }} API"
     version: Literal[__version__] = __version__
-
-
-class ServiceEnvironment(str, Enum):
-    """Define current environment for service_info field"""
-
-    DEV = "dev"
-    PROD = "prod"
-    TEST = "test"
-    STAGING = "staging"
 
 
 class ServiceInfo(BaseModel):
@@ -54,5 +62,5 @@ class ServiceInfo(BaseModel):
     )
     createdAt: Literal["{% now 'utc', '%Y-%m-%dT%H:%M:%S+00:00' %}"] = "{% now 'utc', '%Y-%m-%dT%H:%M:%S+00:00' %}"  # noqa: N815
     updatedAt: str | None = None  # noqa: N815
-    environment: ServiceEnvironment = ServiceEnvironment.DEV
+    environment: ServiceEnvironment
     version: Literal[__version__] = __version__

--- a/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/models.py
+++ b/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/models.py
@@ -17,14 +17,6 @@ class ServiceEnvironment(str, Enum):
     STAGING = "staging"
 
 
-class Config(BaseModel):
-    """Define app configuration data object."""
-
-    env: ServiceEnvironment
-    debug: bool
-    test: bool
-
-
 class ServiceOrganization(BaseModel):
     """Define service_info response for organization field"""
 

--- a/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/models.py
+++ b/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/models.py
@@ -1,6 +1,8 @@
 """Define models for internal data and API responses."""
 
+from enum import Enum
 from typing import Literal
+
 from pydantic import BaseModel
 
 from . import __version__
@@ -25,17 +27,30 @@ class ServiceType(BaseModel):
     version: Literal["1.0.0"] = "1.0.0"
 
 
-class ServiceInfo(BaseModel):
-    """Define response structure for GA4GH service_info endpoint."""
+class ServiceEnvironment(str, Enum):
+    """Define current environment for service_info field"""
 
+    DEV = "dev"
+    PROD = "prod"
+
+
+class ServiceInfo(BaseModel):
+    """Define response structure for GA4GH /service_info endpoint."""
+
+    id: Literal["org.genomicmedlab.{{ cookiecutter.project_slug }}"] = (
+        "org.genomicmedlab.{{ cookiecutter.project_slug }}"
+    )
     name: Literal["{{ cookiecutter.project_slug }}"] = "{{ cookiecutter.project_slug }}"
-    id: Literal["org.genomicmedlab.{{ cookiecutter.project_slug }}"] = "org.genomicmedlab.{{ cookiecutter.project_slug }}"
-    description: Literal["{{ cookiecutter.description }}"] = "{{ cookiecutter.description }}"
     type: ServiceType
+    description: Literal["{{ cookiecutter.description }}"] = "{{ cookiecutter.description }}"
     organization: ServiceOrganization
-    version: Literal[__version__] = __version__
-    contact_url: Literal["Alex.Wagner@nationwidechildrens.org"] = (
+    contactUrl: Literal["Alex.Wagner@nationwidechildrens.org"] = (  # noqa: N815
         "Alex.Wagner@nationwidechildrens.org"
+    )
+    documentationUrl: Literal["https://github.com/{{ cookiecutter.org }}/{{ cookiecutter.repo }}"] = (  # noqa: N815
+        "https://github.com/{{ cookiecutter.org }}/{{ cookiecutter.repo }}"
     )
     createdAt: Literal["{% now 'utc', '%Y-%m-%dT%H:%M:%S+00:00' %}"] = "{% now 'utc', '%Y-%m-%dT%H:%M:%S+00:00' %}"  # noqa: N815
     updatedAt: str | None = None  # noqa: N815
+    environment: ServiceEnvironment = ServiceEnvironment.DEV
+    version: Literal[__version__] = __version__

--- a/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/models.py
+++ b/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/models.py
@@ -24,7 +24,7 @@ class ServiceType(BaseModel):
 
     group: Literal["org.genomicmedlab"] = "org.genomicmedlab"
     artifact: Literal["{{ cookiecutter.project_slug }} API"] = "{{ cookiecutter.project_slug }} API"
-    version: Literal["1.0.0"] = "1.0.0"
+    version: Literal[__version__] = __version__
 
 
 class ServiceEnvironment(str, Enum):

--- a/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/models.py
+++ b/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/models.py
@@ -32,6 +32,8 @@ class ServiceEnvironment(str, Enum):
 
     DEV = "dev"
     PROD = "prod"
+    TEST = "test"
+    STAGING = "staging"
 
 
 class ServiceInfo(BaseModel):

--- a/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/models.py
+++ b/python/{{cookiecutter.project_slug}}/src/{{cookiecutter.project_slug}}/models.py
@@ -1,0 +1,41 @@
+"""Define models for internal data and API responses."""
+
+from typing import Literal
+from pydantic import BaseModel
+
+from . import __version__
+
+
+class ServiceOrganization(BaseModel):
+    """Define service_info response for organization field"""
+
+    name: Literal["Genomic Medicine Lab at Nationwide Children's Hospital"] = (
+        "Genomic Medicine Lab at Nationwide Children's Hospital"
+    )
+    url: Literal[
+        "https://www.nationwidechildrens.org/specialties/institute-for-genomic-medicine/research-labs/wagner-lab"
+    ] = "https://www.nationwidechildrens.org/specialties/institute-for-genomic-medicine/research-labs/wagner-lab"
+
+
+class ServiceType(BaseModel):
+    """Define service_info response for type field"""
+
+    group: Literal["org.genomicmedlab"] = "org.genomicmedlab"
+    artifact: Literal["{{ cookiecutter.project_slug }} API"] = "{{ cookiecutter.project_slug }} API"
+    version: Literal["1.0.0"] = "1.0.0"
+
+
+class ServiceInfo(BaseModel):
+    """Define response structure for GA4GH service_info endpoint."""
+
+    name: Literal["{{ cookiecutter.project_slug }}"] = "{{ cookiecutter.project_slug }}"
+    id: Literal["org.genomicmedlab.{{ cookiecutter.project_slug }}"] = "org.genomicmedlab.{{ cookiecutter.project_slug }}"
+    description: Literal["{{ cookiecutter.description }}"] = "{{ cookiecutter.description }}"
+    type: ServiceType
+    organization: ServiceOrganization
+    version: Literal[__version__] = __version__
+    contact_url: Literal["Alex.Wagner@nationwidechildrens.org"] = (
+        "Alex.Wagner@nationwidechildrens.org"
+    )
+    createdAt: Literal["{% now 'utc', '%Y-%m-%dT%H:%M:%S+00:00' %}"] = "{% now 'utc', '%Y-%m-%dT%H:%M:%S+00:00' %}"  # noqa: N815
+    updatedAt: str | None = None  # noqa: N815

--- a/python/{{cookiecutter.project_slug}}/tests/conftest.py
+++ b/python/{{cookiecutter.project_slug}}/tests/conftest.py
@@ -1,7 +1,8 @@
 def pytest_addoption(parser):
     """Add custom commands to pytest invocation.
 
-    See https://docs.pytest.org/en/8.1.x/reference/reference.html#parser"""
+    See https://docs.pytest.org/en/8.1.x/reference/reference.html#parser
+    """
     parser.addoption(
         "--verbose-logs",
         action="store_true",

--- a/python/{{cookiecutter.project_slug}}/tests/test_api.py
+++ b/python/{{cookiecutter.project_slug}}/tests/test_api.py
@@ -18,11 +18,13 @@ def api_client():
 def test_service_info(api_client: TestClient):
     response = api_client.get("/service_info")
     assert response.status_code == 200
+    EXPECTED_VERSION_PATTERN = r"\d\.\d\."
     response_json = response.json()
     assert response_json["id"] == "org.genomicmedlab.{{ cookiecutter.project_slug }}"
     assert response_json["name"] == "{{ cookiecutter.project_slug }}"
     assert response_json["type"]["group"] == "org.genomicmedlab"
     assert response_json["type"]["artifact"] == "{{ cookiecutter.project_slug }} API"
+    assert re.match(EXPECTED_VERSION_PATTERN, response_json["type"]["version"])
     assert response_json["description"] == "{{ cookiecutter.description }}"
     assert response_json["organization"] == {
         "name": "Genomic Medicine Lab at Nationwide Children's Hospital",
@@ -35,13 +37,4 @@ def test_service_info(api_client: TestClient):
     )
     assert datetime.fromisoformat(response_json["createdAt"])
     assert ServiceEnvironment(response_json["environment"])
-
-
-def test_service_info_version(api_client: TestClient):
-    """Early in development, we expect `__version__` to be None, but it shouldn't be
-    once a version tag is made. Therefore, this test is broken out so that it can be easily
-    ignored while initial development is ongoing.
-    """
-    response_json = api_client.get("/service_info").json()
-    assert re.match(r"\d\.\d\.\d\.", response_json["type"]["version"])
-    assert re.match(r"\d\.\d\.\d\.", response_json["version"])
+    assert re.match(EXPECTED_VERSION_PATTERN, response_json["version"])

--- a/python/{{cookiecutter.project_slug}}/tests/test_api.py
+++ b/python/{{cookiecutter.project_slug}}/tests/test_api.py
@@ -2,8 +2,8 @@
 
 import re
 
-from fastapi.testclient import TestClient
 import pytest
+from fastapi.testclient import TestClient
 
 from {{ cookiecutter.project_slug }}.api import app
 from {{ cookiecutter.project_slug }}.models import ServiceEnvironment
@@ -26,9 +26,22 @@ def test_service_info(api_client: TestClient):
     assert response_json["description"] == "{{ cookiecutter.description }}"
     assert response_json["organization"] == {
         "name": "Genomic Medicine Lab at Nationwide Children's Hospital",
-        "url": "https://www.nationwidechildrens.org/specialties/institute-for-genomic-medicine/research-labs/wagner-lab"
+        "url": "https://www.nationwidechildrens.org/specialties/institute-for-genomic-medicine/research-labs/wagner-lab",
     }
     assert response_json["contactUrl"] == "Alex.Wagner@nationwidechildrens.org"
-    assert response_json["documentationUrl"] == "https://github.com/{{ cookiecutter.org }}/{{ cookiecutter.repo }}"
+    assert (
+        response_json["documentationUrl"]
+        == "https://github.com/{{ cookiecutter.org }}/{{ cookiecutter.repo }}"
+    )
     assert ServiceEnvironment(response_json["environment"])
+    assert re.match(r"\d\.\d\.\d\.", response_json["version"])
+
+
+def test_service_info_version(api_client: TestClient):
+    """Early in development, we expect `__version__` to be None, but it shouldn't be
+    once a version tag is made. Therefore, this test is broken out so that it can be easily
+    ignored while initial development is ongoing.
+    """
+    response_json = api_client.get("/service_info").json()
+    assert re.match(r"\d\.\d\.\d\.", response_json["type"]["version"])
     assert re.match(r"\d\.\d\.\d\.", response_json["version"])

--- a/python/{{cookiecutter.project_slug}}/tests/test_api.py
+++ b/python/{{cookiecutter.project_slug}}/tests/test_api.py
@@ -1,5 +1,6 @@
 """Test FastAPI endpoint function."""
 
+from datetime import datetime
 import re
 
 import pytest
@@ -22,7 +23,6 @@ def test_service_info(api_client: TestClient):
     assert response_json["name"] == "{{ cookiecutter.project_slug }}"
     assert response_json["type"]["group"] == "org.genomicmedlab"
     assert response_json["type"]["artifact"] == "{{ cookiecutter.project_slug }} API"
-    assert re.match(r"\d\.\d\.\d\.", response_json["type"]["version"])
     assert response_json["description"] == "{{ cookiecutter.description }}"
     assert response_json["organization"] == {
         "name": "Genomic Medicine Lab at Nationwide Children's Hospital",
@@ -33,8 +33,8 @@ def test_service_info(api_client: TestClient):
         response_json["documentationUrl"]
         == "https://github.com/{{ cookiecutter.org }}/{{ cookiecutter.repo }}"
     )
+    assert datetime.fromisoformat(response_json["createdAt"])
     assert ServiceEnvironment(response_json["environment"])
-    assert re.match(r"\d\.\d\.\d\.", response_json["version"])
 
 
 def test_service_info_version(api_client: TestClient):

--- a/python/{{cookiecutter.project_slug}}/tests/test_api.py
+++ b/python/{{cookiecutter.project_slug}}/tests/test_api.py
@@ -18,13 +18,13 @@ def api_client():
 def test_service_info(api_client: TestClient):
     response = api_client.get("/service_info")
     assert response.status_code == 200
-    EXPECTED_VERSION_PATTERN = r"\d\.\d\."
+    expected_version_pattern = r"\d\.\d\."  # at minimum, should be something like "0.1"
     response_json = response.json()
     assert response_json["id"] == "org.genomicmedlab.{{ cookiecutter.project_slug }}"
     assert response_json["name"] == "{{ cookiecutter.project_slug }}"
     assert response_json["type"]["group"] == "org.genomicmedlab"
     assert response_json["type"]["artifact"] == "{{ cookiecutter.project_slug }} API"
-    assert re.match(EXPECTED_VERSION_PATTERN, response_json["type"]["version"])
+    assert re.match(expected_version_pattern, response_json["type"]["version"])
     assert response_json["description"] == "{{ cookiecutter.description }}"
     assert response_json["organization"] == {
         "name": "Genomic Medicine Lab at Nationwide Children's Hospital",
@@ -37,4 +37,4 @@ def test_service_info(api_client: TestClient):
     )
     assert datetime.fromisoformat(response_json["createdAt"])
     assert ServiceEnvironment(response_json["environment"])
-    assert re.match(EXPECTED_VERSION_PATTERN, response_json["version"])
+    assert re.match(expected_version_pattern, response_json["version"])

--- a/python/{{cookiecutter.project_slug}}/tests/test_api.py
+++ b/python/{{cookiecutter.project_slug}}/tests/test_api.py
@@ -1,0 +1,34 @@
+"""Test FastAPI endpoint function."""
+
+import re
+
+from fastapi.testclient import TestClient
+import pytest
+
+from {{ cookiecutter.project_slug }}.api import app
+from {{ cookiecutter.project_slug }}.models import ServiceEnvironment
+
+
+@pytest.fixture(scope="module")
+def api_client():
+    return TestClient(app)
+
+
+def test_service_info(api_client: TestClient):
+    response = api_client.get("/service_info")
+    assert response.status_code == 200
+    response_json = response.json()
+    assert response_json["id"] == "org.genomicmedlab.{{ cookiecutter.project_slug }}"
+    assert response_json["name"] == "{{ cookiecutter.project_slug }}"
+    assert response_json["type"]["group"] == "org.genomicmedlab"
+    assert response_json["type"]["artifact"] == "{{ cookiecutter.project_slug }} API"
+    assert re.match(r"\d\.\d\.\d\.", response_json["type"]["version"])
+    assert response_json["description"] == "{{ cookiecutter.description }}"
+    assert response_json["organization"] == {
+        "name": "Genomic Medicine Lab at Nationwide Children's Hospital",
+        "url": "https://www.nationwidechildrens.org/specialties/institute-for-genomic-medicine/research-labs/wagner-lab"
+    }
+    assert response_json["contactUrl"] == "Alex.Wagner@nationwidechildrens.org"
+    assert response_json["documentationUrl"] == "https://github.com/{{ cookiecutter.org }}/{{ cookiecutter.repo }}"
+    assert ServiceEnvironment(response_json["environment"])
+    assert re.match(r"\d\.\d\.\d\.", response_json["version"])

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ click==8.1.7
 cookiecutter==2.5.0
 idna==3.6
 Jinja2==3.1.3
+jinja2-time==0.2.0
 markdown-it-py==3.0.0
 MarkupSafe==2.1.4
 mdurl==0.1.2


### PR DESCRIPTION
close #75 

this became much bigger than planned, but it reflects a few aspirations for what a service-like application should probably look like

* FastAPI `api.py` module, including a `/service_info` endpoint conforming to the GA4GH spec. I didn't bother implementing `updatedAt` (it's optional) because I think it'd be kind of a hassle to update a datetime object every time we make a release. Maybe there's a way to automate this but not a priority IMO.
* An API tests module with reasonable coverage
* A library config module. I don't think we have any services right now that *quite* map to the dev/test/staging/prod schema (I took this from rails), but some are pretty close and we could tweak as needed. The idea here is that it's a central source of truth about what kind of an environment the app is running in, and then other modules (like a database module or the main API views module) refer to it when making environment-based decisions. The individual settings here (`test` and `debug`) are sort of general/predictive of what we might need in a given app. Lots of examples online also set a `DB URL` or DB connection configs here as well. (I also looked at `pydantic-settings` for this but I think it's a lot more than we need. )
* A logging setup module. This would also be shared with a CLI module (which is my next project for this repo).
* Add `FAST` rules from `ruff`.

The service info spec lets you add your own additional fields if desired. For DGIdb, Adam added a "data version" field, for example. There's probably things we could do there for many of our APIs.