### PR TITLE
feat(python): add conftest.py

### DIFF
--- a/python/{{cookiecutter.project_slug}}/tests/conftest.py
+++ b/python/{{cookiecutter.project_slug}}/tests/conftest.py
@@ -1,0 +1,21 @@
+def pytest_addoption(parser):
+    """Add custom commands to pytest invocation.
+
+    See https://docs.pytest.org/en/8.1.x/reference/reference.html#parser"""
+    parser.addoption(
+        "--verbose-logs",
+        action="store_true",
+        default=False,
+        help="show noisy module logs",
+    )
+
+
+def pytest_configure(config):
+    """Configure pytest setup."""
+    # add noisy logging libraries.
+    if not config.getoption("--verbose-logs"):
+        pass
+        # for example:
+        # logging.getLogger("botocore").setLevel(logging.ERROR)
+        # logging.getLogger("boto3").setLevel(logging.ERROR)
+        # logging.getLogger("urllib3.connectionpool").setLevel(logging.ERROR)


### PR DESCRIPTION
Motivated by two things

* the "noisy logs" thing really is annoying in a lot of our stuff and it'd be nice to have the code there to handle it. Easy to delete where it's really unnecessary
* I wanted to add a set of tests to the FastAPI branch I'm working on, but the template doesn't currently include any tests by default, so I wanted to have a little bit of a skeleton there.