### PR TITLE
cicd: fix precommit autoupdate job

### DIFF
--- a/.github/workflows/update-python.yaml
+++ b/.github/workflows/update-python.yaml
@@ -47,7 +47,7 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          if git diff --quiet origin/main..; then
+          if git diff --quiet; then
             echo "new_commits=false" >> $GITHUB_ENV
             exit 0
           else
@@ -104,7 +104,7 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          if git diff --quiet origin/main..; then
+          if git diff --quiet; then
             echo "new_commits=false" >> $GITHUB_ENV
             exit 0
           else
@@ -154,7 +154,7 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          if git diff --quiet origin/main..; then
+          if git diff --quiet; then
             echo "new_commits=false" >> $GITHUB_ENV
             exit 0
           else

--- a/.github/workflows/update-python.yaml
+++ b/.github/workflows/update-python.yaml
@@ -100,24 +100,20 @@ jobs:
         run: |
           sed -i "s/minimum_pre_commit_version: .*/minimum_pre_commit_version: ${{ env.PRECOMMIT_VERSION }}/" ${{ env.PYTHON_TEMPLATE_LOCATION }}/.pre-commit-config.yaml
 
-      - name: Create new branch for changes
-        run: |
-          git checkout -b update-precommit-${{ env.PRECOMMIT_VERSION }}
-
       - name: Create new branch, commit, and push changes
         run: |
-          git checkout -b update-ruff-${{ env.RUFF_VERSION }}
+          git checkout -b update-precommit-${{ env.PRECOMMIT_VERSION }}
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add ${{ env.PYTHON_TEMPLATE_LOCATION }}/pyproject.toml ${{ env.PYTHON_TEMPLATE_LOCATION }}/.pre-commit-config.yaml
-          git commit -m "Update ruff version to ${{ env.RUFF_VERSION }}"
+          git commit -m "Update precommit to ${{ env.PRECOMMIT_VERSION }}"
           if git diff --quiet origin/main..; then
             echo "new_commits=false" >> $GITHUB_ENV
             exit 0
           else
             echo "new_commits=true" >> $GITHUB_ENV
           fi;
-          git push --set-upstream origin update-ruff-${{ env.RUFF_VERSION }}
+          git push --set-upstream origin update-precommit-${{ env.PRECOMMIT_VERSION }}
 
       - name: Create pull request
         if: env.new_commits == 'true'
@@ -154,24 +150,20 @@ jobs:
         run: |
           sed -i "s/rev: .*  # pre-commit-hooks version/rev: ${{ env.PRECOMMIT_HOOKS_VERSION }}  # pre-commit-hooks version/" ${{ env.PYTHON_TEMPLATE_LOCATION }}/.pre-commit-config.yaml
 
-      - name: Create new branch for changes
-        run: |
-          git checkout -b update-precommit-hooks-${{ env.PRECOMMIT_HOOKS_VERSION }}
-
       - name: Create new branch, commit, and push changes
         run: |
-          git checkout -b update-ruff-${{ env.RUFF_VERSION }}
+          git checkout -b update-precommit-hooks-${{ env.PRECOMMIT_HOOKS_VERSION }}
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add ${{ env.PYTHON_TEMPLATE_LOCATION }}/pyproject.toml ${{ env.PYTHON_TEMPLATE_LOCATION }}/.pre-commit-config.yaml
-          git commit -m "Update ruff version to ${{ env.RUFF_VERSION }}"
+          git add ${{ env.PYTHON_TEMPLATE_LOCATION }}/.pre-commit-config.yaml
+          git commit -m "Update pre-commit-hooks version to ${{ env.PRECOMMIT_HOOKS_VERSION }}"
           if git diff --quiet origin/main..; then
             echo "new_commits=false" >> $GITHUB_ENV
             exit 0
           else
             echo "new_commits=true" >> $GITHUB_ENV
           fi;
-          git push --set-upstream origin update-ruff-${{ env.RUFF_VERSION }}
+          git push --set-upstream origin update-precommit-hooks-${{ env.PRECOMMIT_HOOKS_VERSION }}
 
       - name: Create pull request
         if: env.new_commits == 'true'

--- a/.github/workflows/update-python.yaml
+++ b/.github/workflows/update-python.yaml
@@ -54,7 +54,16 @@ jobs:
           git commit -m "Update ruff version to ${{ env.RUFF_VERSION }}" || exit 0 # Exit gracefully if no changes
           git push --set-upstream origin update-ruff-${{ env.RUFF_VERSION }}
 
+      - name: Check if there are new commits
+        id: check_commits
+        run: |
+          if git diff --quiet origin/main..; then
+            echo "new_commits=false" >> $GITHUB_ENV
+          else
+            echo "new_commits=true" >> $GITHUB_ENV
+
       - name: Create pull request
+        if: env.new_commits == 'true'
         run: |
           gh pr create --title "style(python): update ruff to ${{ env.RUFF_VERSION }}" \
                        --body "Automatically update the Ruff version in \`pyproject.toml\` and \`.pre-commit-config.yaml\`." \
@@ -65,8 +74,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  update_precommit:
-    name: Update Python pre-commit version pins
+  update_precommit_and_hooks:
+    name: Update Python pre-commit version pins and hooks
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -89,11 +98,14 @@ jobs:
 
       - name: Update pre-commit version in pyproject.toml
         run: |
-          sed -i "s/\"pre-commit==.*\"/\"pre-commit==${{ env.PRECOMMIT_VERSION }}\"/" ${{ env.PYTHON_TEMPLATE_LOCATION }}/pyproject.toml
+          sed -i "s/\"pre-commit>=.*\"/\"pre-commit>=${{ env.PRECOMMIT_VERSION }}\"/" ${{ env.PYTHON_TEMPLATE_LOCATION }}/pyproject.toml
 
       - name: Update min pre-commit version requirement in .pre-commit-config.yaml
         run: |
           sed -i "s/minimum_pre_commit_version: .*/minimum_pre_commit_version: ${{ env.PRECOMMIT_VERSION }}/" ${{ env.PYTHON_TEMPLATE_LOCATION }}/.pre-commit-config.yaml
+
+      - name: Update pre-commit-hooks version requirement
+        run: pre-commit autoupdate --repo https://github.com/pre-commit/pre-commit-hooks
 
       - name: Create new branch for changes
         run: |
@@ -107,58 +119,21 @@ jobs:
           git commit -m "Update precommit version to ${{ env.PRECOMMIT_VERSION }}" || exit 0 # Exit gracefully if no changes
           git push --set-upstream origin update-precommit-${{ env.PRECOMMIT_VERSION }}
 
+      - name: Check if there are new commits
+        id: check_commits
+        run: |
+          if git diff --quiet origin/main..; then
+            echo "new_commits=false" >> $GITHUB_ENV
+          else
+            echo "new_commits=true" >> $GITHUB_ENV
+
       - name: Create pull request
+        if: env.new_commits == 'true'
         run: |
           gh pr create --title "cicd(python): update precommit to ${{ env.PRECOMMIT_VERSION }}" \
                        --body "Automatically update the pre-commit version in \`pyproject.toml\` and \`.pre-commit-config.yaml\`." \
                        --base main \
                        --head update-precommit-${{ env.PRECOMMIT_VERSION }} \
-                       --reviewer "jsstevenson,korikuzma" \
-                       --label "priority:low"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  update_precommit_hooks:
-    name: Update Python pre-commit-hooks version pins
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.MIN_PYTHON_VERSION }}
-
-      - name: Get latest pre-commit-hooks version
-        run: |
-          latest_tag=$(curl -s https://api.github.com/repos/pre-commit/pre-commit-hooks/releases | jq -r '.[0].tag_name')
-          echo "PRECOMMIT_HOOKS_VERSION=$latest_tag" >> $GITHUB_ENV
-
-      - name: Update pre-commit-hooks version in .pre-commit-config.yaml
-        run: |
-          sed -i "s/rev: .*  # pre-commit-hooks version/rev: ${{ env.PRECOMMIT_HOOKS_VERSION }}  # pre-commit-hooks version/" ${{ env.PYTHON_TEMPLATE_LOCATION }}/.pre-commit-config.yaml
-
-      - name: Create new branch for changes
-        run: |
-          git checkout -b update-precommit-hooks-${{ env.PRECOMMIT_HOOKS_VERSION }}
-
-      - name: Commit and push changes
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add ${{ env.PYTHON_TEMPLATE_LOCATION }}/.pre-commit-config.yaml
-          git commit -m "Update pre-commit-hooks version to ${{ env.PRECOMMIT_HOOKS_VERSION }}" || exit 0 # Exit gracefully if no changes
-          git push --set-upstream origin update-precommit-hooks-${{ env.PRECOMMIT_HOOKS_VERSION }}
-
-      - name: Create pull request
-        run: |
-          gh pr create --title "cicd(python): update pre-commit-hooks to ${{ env.PRECOMMIT_HOOKS_VERSION }}" \
-                       --body "Automatically update the pre-commit-hooks version in \`.pre-commit-config.yaml\`." \
-                       --base main \
-                       --head update-precommit-hooks-${{ env.PRECOMMIT_HOOKS_VERSION }} \
                        --reviewer "jsstevenson,korikuzma" \
                        --label "priority:low"
         env:

--- a/.github/workflows/update-python.yaml
+++ b/.github/workflows/update-python.yaml
@@ -62,6 +62,7 @@ jobs:
             echo "new_commits=false" >> $GITHUB_ENV
           else
             echo "new_commits=true" >> $GITHUB_ENV
+          fi;
 
       - name: Create pull request
         if: env.new_commits == 'true'
@@ -105,9 +106,6 @@ jobs:
         run: |
           sed -i "s/minimum_pre_commit_version: .*/minimum_pre_commit_version: ${{ env.PRECOMMIT_VERSION }}/" ${{ env.PYTHON_TEMPLATE_LOCATION }}/.pre-commit-config.yaml
 
-      - name: Update pre-commit-hooks version requirement
-        run: pre-commit autoupdate --repo https://github.com/pre-commit/pre-commit-hooks
-
       - name: Create new branch for changes
         run: |
           git checkout -b update-precommit-${{ env.PRECOMMIT_VERSION }}
@@ -127,6 +125,7 @@ jobs:
             echo "new_commits=false" >> $GITHUB_ENV
           else
             echo "new_commits=true" >> $GITHUB_ENV
+          fi;
 
       - name: Create pull request
         if: env.new_commits == 'true'
@@ -135,6 +134,62 @@ jobs:
                        --body "Automatically update the pre-commit version in \`pyproject.toml\` and \`.pre-commit-config.yaml\`." \
                        --base main \
                        --head update-precommit-${{ env.PRECOMMIT_VERSION }} \
+                       --reviewer "jsstevenson,korikuzma" \
+                       --label "priority:low"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  update_precommit_hooks:
+    name: Update Python pre-commit-hooks version pins
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.MIN_PYTHON_VERSION }}
+
+      - name: Get latest pre-commit-hooks version
+        run: |
+          latest_tag=$(curl -s https://api.github.com/repos/pre-commit/pre-commit-hooks/releases | jq -r '.[0].tag_name')
+          echo "PRECOMMIT_HOOKS_VERSION=$latest_tag" >> $GITHUB_ENV
+
+      - name: Update pre-commit-hooks version in .pre-commit-config.yaml
+        run: |
+          sed -i "s/rev: .*  # pre-commit-hooks version/rev: ${{ env.PRECOMMIT_HOOKS_VERSION }}  # pre-commit-hooks version/" ${{ env.PYTHON_TEMPLATE_LOCATION }}/.pre-commit-config.yaml
+
+      - name: Create new branch for changes
+        run: |
+          git checkout -b update-precommit-hooks-${{ env.PRECOMMIT_HOOKS_VERSION }}
+
+      - name: Commit and push changes
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add ${{ env.PYTHON_TEMPLATE_LOCATION }}/.pre-commit-config.yaml
+          git commit -m "Update pre-commit-hooks version to ${{ env.PRECOMMIT_HOOKS_VERSION }}" || exit 0 # Exit gracefully if no changes
+          git push --set-upstream origin update-precommit-hooks-${{ env.PRECOMMIT_HOOKS_VERSION }}
+
+      - name: Check if there are new commits
+        id: check_commits
+        run: |
+          if git diff --quiet origin/main..; then
+            echo "new_commits=false" >> $GITHUB_ENV
+          else
+            echo "new_commits=true" >> $GITHUB_ENV
+          fi;
+
+      - name: Create pull request
+        if: env.new_commits == 'true'
+        run: |
+          gh pr create --title "cicd(python): update pre-commit-hooks to ${{ env.PRECOMMIT_HOOKS_VERSION }}" \
+                       --body "Automatically update the pre-commit-hooks version in \`.pre-commit-config.yaml\`." \
+                       --base main \
+                       --head update-precommit-hooks-${{ env.PRECOMMIT_HOOKS_VERSION }} \
                        --reviewer "jsstevenson,korikuzma" \
                        --label "priority:low"
         env:

--- a/.github/workflows/update-python.yaml
+++ b/.github/workflows/update-python.yaml
@@ -49,11 +49,11 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add ${{ env.PYTHON_TEMPLATE_LOCATION }}/pyproject.toml ${{ env.PYTHON_TEMPLATE_LOCATION }}/.pre-commit-config.yaml
-          git commit -m "Update ruff version to ${{ env.RUFF_VERSION }}"
           if git diff --quiet origin/main..; then
             echo "new_commits=false" >> $GITHUB_ENV
             exit 0
           else
+            git commit -m "Update ruff version to ${{ env.RUFF_VERSION }}"
             echo "new_commits=true" >> $GITHUB_ENV
           fi;
           git push --set-upstream origin update-ruff-${{ env.RUFF_VERSION }}
@@ -106,11 +106,11 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add ${{ env.PYTHON_TEMPLATE_LOCATION }}/pyproject.toml ${{ env.PYTHON_TEMPLATE_LOCATION }}/.pre-commit-config.yaml
-          git commit -m "Update precommit to ${{ env.PRECOMMIT_VERSION }}"
           if git diff --quiet origin/main..; then
             echo "new_commits=false" >> $GITHUB_ENV
             exit 0
           else
+            git commit -m "Update precommit to ${{ env.PRECOMMIT_VERSION }}"
             echo "new_commits=true" >> $GITHUB_ENV
           fi;
           git push --set-upstream origin update-precommit-${{ env.PRECOMMIT_VERSION }}
@@ -156,11 +156,11 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add ${{ env.PYTHON_TEMPLATE_LOCATION }}/.pre-commit-config.yaml
-          git commit -m "Update pre-commit-hooks version to ${{ env.PRECOMMIT_HOOKS_VERSION }}"
           if git diff --quiet origin/main..; then
             echo "new_commits=false" >> $GITHUB_ENV
             exit 0
           else
+            git commit -m "Update pre-commit-hooks version to ${{ env.PRECOMMIT_HOOKS_VERSION }}"
             echo "new_commits=true" >> $GITHUB_ENV
           fi;
           git push --set-upstream origin update-precommit-hooks-${{ env.PRECOMMIT_HOOKS_VERSION }}

--- a/.github/workflows/update-python.yaml
+++ b/.github/workflows/update-python.yaml
@@ -45,14 +45,14 @@ jobs:
 
       - name: Create new branch, commit, and push changes
         run: |
-          git checkout -b update-ruff-${{ env.RUFF_VERSION }}
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add ${{ env.PYTHON_TEMPLATE_LOCATION }}/pyproject.toml ${{ env.PYTHON_TEMPLATE_LOCATION }}/.pre-commit-config.yaml
           if git diff --quiet origin/main..; then
             echo "new_commits=false" >> $GITHUB_ENV
             exit 0
           else
+            git checkout -b update-ruff-${{ env.RUFF_VERSION }}
+            git add ${{ env.PYTHON_TEMPLATE_LOCATION }}/pyproject.toml ${{ env.PYTHON_TEMPLATE_LOCATION }}/.pre-commit-config.yaml
             git commit -m "Update ruff version to ${{ env.RUFF_VERSION }}"
             echo "new_commits=true" >> $GITHUB_ENV
           fi;
@@ -102,14 +102,14 @@ jobs:
 
       - name: Create new branch, commit, and push changes
         run: |
-          git checkout -b update-precommit-${{ env.PRECOMMIT_VERSION }}
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add ${{ env.PYTHON_TEMPLATE_LOCATION }}/pyproject.toml ${{ env.PYTHON_TEMPLATE_LOCATION }}/.pre-commit-config.yaml
           if git diff --quiet origin/main..; then
             echo "new_commits=false" >> $GITHUB_ENV
             exit 0
           else
+            git checkout -b update-precommit-${{ env.PRECOMMIT_VERSION }}
+            git add ${{ env.PYTHON_TEMPLATE_LOCATION }}/pyproject.toml ${{ env.PYTHON_TEMPLATE_LOCATION }}/.pre-commit-config.yaml
             git commit -m "Update precommit to ${{ env.PRECOMMIT_VERSION }}"
             echo "new_commits=true" >> $GITHUB_ENV
           fi;
@@ -152,14 +152,14 @@ jobs:
 
       - name: Create new branch, commit, and push changes
         run: |
-          git checkout -b update-precommit-hooks-${{ env.PRECOMMIT_HOOKS_VERSION }}
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add ${{ env.PYTHON_TEMPLATE_LOCATION }}/.pre-commit-config.yaml
           if git diff --quiet origin/main..; then
             echo "new_commits=false" >> $GITHUB_ENV
             exit 0
           else
+            git checkout -b update-precommit-hooks-${{ env.PRECOMMIT_HOOKS_VERSION }}
+            git add ${{ env.PYTHON_TEMPLATE_LOCATION }}/.pre-commit-config.yaml
             git commit -m "Update pre-commit-hooks version to ${{ env.PRECOMMIT_HOOKS_VERSION }}"
             echo "new_commits=true" >> $GITHUB_ENV
           fi;

--- a/.github/workflows/update-python.yaml
+++ b/.github/workflows/update-python.yaml
@@ -43,26 +43,20 @@ jobs:
         run: |
           sed -i "s/rev: .*  # ruff version/rev: v${{ env.RUFF_VERSION }}  # ruff version/" ${{ env.PYTHON_TEMPLATE_LOCATION }}/.pre-commit-config.yaml
 
-      - name: Create new branch for changes
+      - name: Create new branch, commit, and push changes
         run: |
           git checkout -b update-ruff-${{ env.RUFF_VERSION }}
-
-      - name: Commit and push changes
-        run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add ${{ env.PYTHON_TEMPLATE_LOCATION }}/pyproject.toml ${{ env.PYTHON_TEMPLATE_LOCATION }}/.pre-commit-config.yaml
-          git commit -m "Update ruff version to ${{ env.RUFF_VERSION }}" || exit 0 # Exit gracefully if no changes
-          git push --set-upstream origin update-ruff-${{ env.RUFF_VERSION }}
-
-      - name: Check if there are new commits
-        id: check_commits
-        run: |
+          git commit -m "Update ruff version to ${{ env.RUFF_VERSION }}"
           if git diff --quiet origin/main..; then
             echo "new_commits=false" >> $GITHUB_ENV
+            exit 0
           else
             echo "new_commits=true" >> $GITHUB_ENV
           fi;
+          git push --set-upstream origin update-ruff-${{ env.RUFF_VERSION }}
 
       - name: Create pull request
         if: env.new_commits == 'true'
@@ -110,22 +104,20 @@ jobs:
         run: |
           git checkout -b update-precommit-${{ env.PRECOMMIT_VERSION }}
 
-      - name: Commit and push changes
+      - name: Create new branch, commit, and push changes
         run: |
+          git checkout -b update-ruff-${{ env.RUFF_VERSION }}
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add ${{ env.PYTHON_TEMPLATE_LOCATION }}/pyproject.toml ${{ env.PYTHON_TEMPLATE_LOCATION }}/.pre-commit-config.yaml
-          git commit -m "Update precommit version to ${{ env.PRECOMMIT_VERSION }}" || exit 0 # Exit gracefully if no changes
-          git push --set-upstream origin update-precommit-${{ env.PRECOMMIT_VERSION }}
-
-      - name: Check if there are new commits
-        id: check_commits
-        run: |
+          git commit -m "Update ruff version to ${{ env.RUFF_VERSION }}"
           if git diff --quiet origin/main..; then
             echo "new_commits=false" >> $GITHUB_ENV
+            exit 0
           else
             echo "new_commits=true" >> $GITHUB_ENV
           fi;
+          git push --set-upstream origin update-ruff-${{ env.RUFF_VERSION }}
 
       - name: Create pull request
         if: env.new_commits == 'true'
@@ -166,22 +158,20 @@ jobs:
         run: |
           git checkout -b update-precommit-hooks-${{ env.PRECOMMIT_HOOKS_VERSION }}
 
-      - name: Commit and push changes
+      - name: Create new branch, commit, and push changes
         run: |
+          git checkout -b update-ruff-${{ env.RUFF_VERSION }}
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add ${{ env.PYTHON_TEMPLATE_LOCATION }}/.pre-commit-config.yaml
-          git commit -m "Update pre-commit-hooks version to ${{ env.PRECOMMIT_HOOKS_VERSION }}" || exit 0 # Exit gracefully if no changes
-          git push --set-upstream origin update-precommit-hooks-${{ env.PRECOMMIT_HOOKS_VERSION }}
-
-      - name: Check if there are new commits
-        id: check_commits
-        run: |
+          git add ${{ env.PYTHON_TEMPLATE_LOCATION }}/pyproject.toml ${{ env.PYTHON_TEMPLATE_LOCATION }}/.pre-commit-config.yaml
+          git commit -m "Update ruff version to ${{ env.RUFF_VERSION }}"
           if git diff --quiet origin/main..; then
             echo "new_commits=false" >> $GITHUB_ENV
+            exit 0
           else
             echo "new_commits=true" >> $GITHUB_ENV
           fi;
+          git push --set-upstream origin update-ruff-${{ env.RUFF_VERSION }}
 
       - name: Create pull request
         if: env.new_commits == 'true'

--- a/python/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/python/{{cookiecutter.project_slug}}/pyproject.toml
@@ -23,7 +23,10 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 tests = ["pytest", "pytest-cov"]
-dev = ["pre-commit>=3.7.1", "ruff==0.8.6"]
+dev = [
+    "pre-commit>=3.7.1",
+    "ruff==0.8.6",
+]
 {% if cookiecutter.add_docs %}
 docs = [
     "sphinx==6.1.3",


### PR DESCRIPTION
* Use correct pattern for precommit version update
* Merge precommit and precommit-hooks jobs
* Use built-in precommit autoupdater to update hooks
* Gracefully handle case where no update is needed