### PR TITLE
feat(python): add fastapi CLI

### DIFF
--- a/python/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/python/{{cookiecutter.project_slug}}/pyproject.toml
@@ -40,6 +40,9 @@ tests = [
 dev = [
     "pre-commit>=4.2.0",
     "ruff==0.12.1",
+{%- if cookiecutter.add_cli %}
+    "fastapi[standard]"
+{%- endif %}
 ]
 {%- if cookiecutter.add_docs %}
 docs = [


### PR DESCRIPTION
close #111

I think `fastapi dev path/to/my/api.py` is a bit more readable for activity monitoring/debugging than the uvicorn builtin printing
