### PR TITLE
fix: use correct settings group for fastapi cli

### DIFF
--- a/python/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/python/{{cookiecutter.project_slug}}/pyproject.toml
@@ -40,7 +40,7 @@ tests = [
 dev = [
     "pre-commit>=4.2.0",
     "ruff==0.12.1",
-{%- if cookiecutter.add_cli %}
+{%- if cookiecutter.add_fastapi %}
     "fastapi[standard]"
 {%- endif %}
 ]


### PR DESCRIPTION
My brain clearly got my wires crossed. This adds the FastAPI CLI, but it's for the FastAPI group, not the CLI (click) group
